### PR TITLE
Do not try to create empty commits

### DIFF
--- a/.github/workflows/ECDC.yml
+++ b/.github/workflows/ECDC.yml
@@ -33,7 +33,7 @@ jobs:
         git config user.email "action@github.com"
         git config user.name "GitHub Action - ECDC"
         git add --all
-        git commit -m "ECDC - daily"
+        git commit -m "ECDC - daily" || echo "No changes to commit"
         git push
         echo "pushed to github"
       env:


### PR DESCRIPTION
This PR should avoid spurious GitHub Actions failure, as in https://github.com/epiforecasts/covid19-forecast-hub-europe/runs/3432410047.